### PR TITLE
Support multiple mapservers in the config

### DIFF
--- a/src/leaflet-autolayers.js
+++ b/src/leaflet-autolayers.js
@@ -483,7 +483,7 @@ L.Control.AutoLayers = L.Control.extend({
 			layers = layers.filter(function(l) {
 				return (l !== undefined && l !== null);
 			});
-			self.mapLayers.concat(layers);
+			self.mapLayers = self.mapLayers.concat(layers);
 			self._initMaps(layers);
 		});
 	},

--- a/src/leaflet-autolayers.js
+++ b/src/leaflet-autolayers.js
@@ -483,7 +483,7 @@ L.Control.AutoLayers = L.Control.extend({
 			layers = layers.filter(function(l) {
 				return (l !== undefined && l !== null);
 			});
-			self.mapLayers.push(layers);
+			self.mapLayers.concat(layers);
 			self._initMaps(layers);
 		});
 	},


### PR DESCRIPTION
If you have a config with multiple mapservers, each with more than 1 layer configured, then only the first list of layers appears in the control.  This is because the `push` of an array `layers` to `self.mapLayers` does not concatenate the list, it creates a second element in the `self.mapLayers` object.  This simple fix solves the issue.